### PR TITLE
by default, open markdown syntax link in new tab

### DIFF
--- a/lib/markdown_deux/templatetags/markdown_deux_tags.py
+++ b/lib/markdown_deux/templatetags/markdown_deux_tags.py
@@ -1,4 +1,3 @@
-
 from django import template
 from django.utils.safestring import mark_safe
 from django.utils.encoding import force_unicode
@@ -68,7 +67,7 @@ def markdown_cheatsheet():
 
 @register.simple_tag
 def markdown_allowed():
-    return ('<a href="%s">Markdown syntax</a> allowed, but no raw HTML. '
+    return ('<a href="%s" target="_blank">Markdown syntax</a> allowed, but no raw HTML. '
         'Examples: **bold**, *italic*, indent 4 spaces for a code block.'
         % settings.MARKDOWN_DEUX_HELP_URL)
 


### PR DESCRIPTION
Thanks for the great project, integrating Markdown into my forms was a breeze! The only thing I ran into was that clicking the link added in via help_text opens in the same tab so you lose the editing you were doing. It might as well open in a new tab. Anyone can override this link of course, but this seems like a reasonable default.
