### PR TITLE
Python 3 support

### DIFF
--- a/lib/markdown_deux/templatetags/markdown_deux_tags.py
+++ b/lib/markdown_deux/templatetags/markdown_deux_tags.py
@@ -1,6 +1,6 @@
 from django import template
 from django.utils.safestring import mark_safe
-from django.utils.encoding import force_unicode
+from django.utils.encoding import force_str
 import markdown_deux
 from markdown_deux.conf import settings
 
@@ -27,7 +27,7 @@ def markdown_filter(value, style="default"):
         if settings.DEBUG:
             raise template.TemplateSyntaxError("Error in `markdown` filter: "
                 "The python-markdown2 library isn't installed.")
-        return force_unicode(value)
+        return force_str(value)
 markdown_filter.is_safe = True
 
 
@@ -57,7 +57,7 @@ class MarkdownNode(template.Node):
             if settings.DEBUG:
                 raise template.TemplateSyntaxError("Error in `markdown` tag: "
                     "The python-markdown2 library isn't installed.")
-            return force_unicode(value)
+            return force_str(value)
 
 
 @register.inclusion_tag("markdown_deux/markdown_cheatsheet.html")


### PR DESCRIPTION
Heya, I made it work with python 3 and django 1.6. Had to replace that force_unicode with force_str instead, so django return a correct string type for python 2 and 3. See https://docs.djangoproject.com/en/1.6/ref/utils/#django.utils.encoding.force_str
