### PR TITLE
Mark the 'markdown_allowed' tag output as safe.

### DIFF
--- a/lib/markdown_deux/__init__.py
+++ b/lib/markdown_deux/__init__.py
@@ -8,7 +8,7 @@ python-markdown2 library.
 See <http://github.com/trentm/django-markdown-deux> for more info.
 """
 
-__version_info__ = (1, 0, 6)
+__version_info__ = (1, 0, 7)
 __version__ = '.'.join(map(str, __version_info__))
 __author__ = "Trent Mick"
 

--- a/lib/markdown_deux/templatetags/markdown_deux_tags.py
+++ b/lib/markdown_deux/templatetags/markdown_deux_tags.py
@@ -1,4 +1,5 @@
 from django import template
+from django.utils.html import format_html
 from django.utils.safestring import mark_safe
 try:
     from django.utils.encoding import force_text
@@ -71,8 +72,8 @@ def markdown_cheatsheet():
 
 @register.simple_tag
 def markdown_allowed():
-    return ('<a href="%s" target="_blank">Markdown syntax</a> allowed, but no raw HTML. '
-        'Examples: **bold**, *italic*, indent 4 spaces for a code block.'
-        % settings.MARKDOWN_DEUX_HELP_URL)
-
-
+    return format_html(
+        '<a href="%s" target="_blank">Markdown syntax</a> allowed, '
+        'but no raw HTML. '
+        'Examples: **bold**, *italic*, indent 4 spaces for a code block.',
+        mark_safe(settings.MARKDOWN_DEUX_HELP_URL))


### PR DESCRIPTION
I don't know if this project is being maintained any more, but I noticed that the "markdown_allowed" tag broke at some point between Django 1.7 and 1.10. I've made a small change to get it working again.